### PR TITLE
ci: fix pnpm setup; run unit+e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          # Use version from root package.json's packageManager to avoid mismatch
+          package_json_file: package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -21,3 +22,9 @@ jobs:
         run: pnpm install --frozen-lockfile=false
       - name: Build
         run: pnpm build
+      - name: Unit tests (Vitest)
+        run: pnpm --filter @syntopia/app test
+      - name: Install Playwright browsers
+        run: pnpm --filter @syntopia/app e2e:install
+      - name: E2E tests (Playwright)
+        run: pnpm --filter @syntopia/app e2e


### PR DESCRIPTION
- Use pnpm/action-setup with package_json_file to align with packageManager in root package.json and avoid version mismatch.
- Install, build, run Vitest unit tests and Playwright e2e in CI.

Verified locally: build + unit + e2e passing.