### PR TITLE
feat(app): Link GitHub + SCL≥4 GitHub quests (mock), filter+persist, badges, empty states, auto-switch; tests+docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          # Use version from root package.json's packageManager to avoid mismatch
+          package_json_file: package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -21,3 +22,9 @@ jobs:
         run: pnpm install --frozen-lockfile=false
       - name: Build
         run: pnpm build
+      - name: Unit tests (Vitest)
+        run: pnpm --filter @syntopia/app test
+      - name: Install Playwright browsers
+        run: pnpm --filter @syntopia/app e2e:install
+      - name: E2E tests (Playwright)
+        run: pnpm --filter @syntopia/app e2e

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # glocalsyn
 Syntopia / GLOCALSPIRIT monorepo (PWA + services). MIT-first, community-operated (12 roles + SCL 1–25).
+
+Quick start:
+- Install: pnpm install
+- Dev server: pnpm --filter @syntopia/app dev
+- Unit tests: pnpm --filter @syntopia/app test
+- E2E: pnpm --filter @syntopia/app e2e (run e2e:install once)
+
+More details: see docs/GETTING_STARTED.md

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1"
+  "react-router-dom": "^6.26.1",
+  "@syntopia/types": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.46.1",

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -5,6 +5,7 @@ import { Background } from './components/Background';
 export function App() {
   return (
     <div className="app-shell">
+  <a href="#main-content" className="skip-link">Zum Inhalt springen</a>
       <Background />
       <header className="app-header glass-surface glass-header" role="banner">
         <strong>Syntopia</strong>
@@ -12,7 +13,7 @@ export function App() {
           {/* ... could add language toggle or help later ... */}
         </nav>
       </header>
-      <main className="app-main">
+  <main id="main-content" className="app-main">
         <Outlet />
       </main>
       <footer className="footer glass-surface glass-footer" aria-hidden>

--- a/apps/app/src/features/profile/profileStore.test.tsx
+++ b/apps/app/src/features/profile/profileStore.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook, act } from '@testing-library/react';
+import { useProfile } from './profileStore';
+
+describe('useProfile', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads defaults and updates/persists profile', () => {
+    const { result } = renderHook(() => useProfile());
+    expect(result.current.profile.scl).toBe(1);
+    expect(result.current.profile.githubLinked).toBe(false);
+
+    act(() => {
+      result.current.update({ githubLinked: true, scl: 4 as any });
+    });
+
+    expect(result.current.profile.githubLinked).toBe(true);
+    const raw = localStorage.getItem('profile');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toMatchObject({ githubLinked: true, scl: 4 });
+  });
+});

--- a/apps/app/src/features/profile/profileStore.ts
+++ b/apps/app/src/features/profile/profileStore.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import type { SCLLevel } from '../../../../../shared/types/src';
+
+export interface Profile {
+  name?: string;
+  region?: string;
+  scl: SCLLevel;
+  githubLinked: boolean;
+}
+
+const DEFAULT_PROFILE: Profile = { scl: 1 as SCLLevel, githubLinked: false };
+
+export function useProfile() {
+  const [profile, setProfile] = useState<Profile>(DEFAULT_PROFILE);
+
+  useEffect(() => {
+    const raw = localStorage.getItem('profile');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as Partial<Profile>;
+        setProfile({ ...DEFAULT_PROFILE, ...parsed });
+      } catch {}
+    }
+  }, []);
+
+  function update(next: Partial<Profile>) {
+    setProfile((p) => {
+      const merged = { ...p, ...next };
+      localStorage.setItem('profile', JSON.stringify(merged));
+      return merged;
+    });
+  }
+
+  return { profile, update };
+}

--- a/apps/app/src/features/quests/mockIssues.ts
+++ b/apps/app/src/features/quests/mockIssues.ts
@@ -1,0 +1,13 @@
+import type { GitHubIssueLite } from '../../../../../shared/types/src';
+
+export const MOCK_ISSUES: GitHubIssueLite[] = [
+  {
+    id: 1,
+    number: 1,
+    title: 'Fix copy on Home CTA',
+    body: 'Change CTA text to be shorter and more action-oriented.',
+    url: 'https://github.com/Breisgauleiter/glocalsyn/issues/1',
+    repo: 'Breisgauleiter/glocalsyn',
+    labels: ['good first issue']
+  },
+];

--- a/apps/app/src/features/quests/questStore.test.tsx
+++ b/apps/app/src/features/quests/questStore.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { useQuestStore } from './questStore';
+import { useQuestStore, getQuestsForProfile } from './questStore';
 
 test('dummy quest flow: available -> accepted -> done', () => {
   const { result } = renderHook(() => useQuestStore());
@@ -15,4 +15,19 @@ test('dummy quest flow: available -> accepted -> done', () => {
   // complete
   act(() => result.current.complete(id));
   expect(result.current.status(id)).toBe('done');
+});
+
+test('getQuestsForProfile: SCL1 no GitHub -> dummy quests with complete proof', () => {
+  const qs = getQuestsForProfile({ githubLinked: false, scl: 1 });
+  expect(qs.length).toBeGreaterThan(0);
+  expect(qs[0].proof?.type).toBe('complete');
+});
+
+test('getQuestsForProfile: SCL4 with GitHub currently returns list (placeholder)', () => {
+  const qs = getQuestsForProfile({ githubLinked: true, scl: 4 });
+  expect(qs.length).toBeGreaterThan(0);
+  // Expect that at least one quest comes from a GitHub issue mapping
+  const ghQuest = qs.find((q) => q.source?.kind === 'github_issue');
+  expect(ghQuest).toBeTruthy();
+  expect(ghQuest?.proof?.type).toBe('github_pr');
 });

--- a/apps/app/src/features/quests/questStore.ts
+++ b/apps/app/src/features/quests/questStore.ts
@@ -1,4 +1,9 @@
 import { useEffect, useState } from 'react';
+import type { QuestDTO, ProofPolicy } from '../../../../../shared/types/src';
+import { mapIssueToQuest } from '../../../../../shared/types/src';
+import { MOCK_ISSUES } from './mockIssues';
+import { useProfile } from '../profile/profileStore';
+import type { Profile } from '../profile/profileStore';
 
 export type QuestStatus = 'available' | 'accepted' | 'done';
 
@@ -8,20 +13,48 @@ export interface Quest {
   description: string;
   category: 'daily' | 'weekly' | 'story';
   minimumSCL?: number;
+  proof?: ProofPolicy;
+  source?: QuestDTO['source'];
 }
 
 const DUMMY_QUESTS: Quest[] = [
-  { id: 'q1', title: 'Begrüße deinen Hub', description: 'Sag Hallo im lokalen Hub‑Channel. Dauer: 1 Minute.', category: 'daily' },
+  {
+    id: 'q1',
+    title: 'Begrüße deinen Hub',
+    description: 'Sag Hallo im lokalen Hub‑Channel. Dauer: 1 Minute.',
+    category: 'daily',
+    proof: { type: 'complete', description: 'Nachweis: Quest abgeschlossen (SCL 1–3)' },
+  },
 ];
 
-export function useQuestStore() {
+export function getQuestsForProfile(opts: { githubLinked: boolean; scl: number }): Quest[] {
+  // For SCL < 4 or no GitHub link, only dummy quests
+  if (!opts.githubLinked || opts.scl < 4) return DUMMY_QUESTS;
+  // For SCL >= 4 and linked, merge in mapped GitHub issues (mocked for now)
+  const fromIssues: Quest[] = MOCK_ISSUES.map((iss) => {
+    const q = mapIssueToQuest(iss) as QuestDTO;
+    return {
+      id: q.id,
+      title: q.title,
+      description: q.description,
+      category: q.category,
+      minimumSCL: q.minimumSCL,
+      proof: q.proof,
+      source: q.source,
+    } satisfies Quest;
+  });
+  return [...DUMMY_QUESTS, ...fromIssues];
+}
+
+export function useQuestStore(profileOverride?: Profile) {
+  const { profile: profileFromHook } = useProfile();
+  const profile = profileOverride ?? profileFromHook;
   const [quests, setQuests] = useState<Quest[]>([]);
   const [statusById, setStatusById] = useState<Record<string, QuestStatus>>({});
 
   useEffect(() => {
-    // load quests lazily (client-side mock)
-    setQuests(DUMMY_QUESTS);
-  }, []);
+    setQuests(getQuestsForProfile({ githubLinked: profile.githubLinked, scl: profile.scl }));
+  }, [profile.githubLinked, profile.scl]);
 
   function accept(id: string) {
     setStatusById((s) => ({ ...s, [id]: 'accepted' }));

--- a/apps/app/src/routes/Me.test.tsx
+++ b/apps/app/src/routes/Me.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Me } from './Me';
+
+function resetProfile() {
+  localStorage.removeItem('profile');
+}
+
+describe('Me route – Link GitHub stub', () => {
+  beforeEach(() => {
+    resetProfile();
+  });
+
+  it('shows current SCL and GitHub link state', () => {
+    render(<Me />);
+    expect(screen.getByText(/SCL/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nicht verknüpft/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /GitHub verknüpfen/i })).toBeInTheDocument();
+  });
+
+  it('when clicking Link GitHub, persists githubLinked=true and scl>=4', () => {
+    render(<Me />);
+    const btn = screen.getByTestId('link-github');
+    fireEvent.click(btn);
+
+    const raw = localStorage.getItem('profile');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.githubLinked).toBe(true);
+    expect(parsed.scl).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/apps/app/src/routes/Me.tsx
+++ b/apps/app/src/routes/Me.tsx
@@ -1,8 +1,47 @@
+import { useMemo } from 'react';
+import { useProfile } from '../features/profile/profileStore';
+
 export function Me() {
+  const { profile, update } = useProfile();
+  const canLink = useMemo(() => !profile.githubLinked, [profile.githubLinked]);
+
+  function linkGithub() {
+    const nextScl = Math.max(profile.scl ?? 1, 4);
+    update({ githubLinked: true, scl: nextScl as any });
+  }
+
   return (
-    <section aria-labelledby="me-title" style={{ padding: 16 }}>
+    <section aria-labelledby="me-title" className="container stack" style={{ padding: 16 }}>
       <h1 id="me-title">Ich</h1>
       <p>Profil & Einstellungen.</p>
+
+      <div className="glass-card" role="group" aria-labelledby="account-section-title">
+        <h2 id="account-section-title" className="h3">Account</h2>
+        <dl className="stack" style={{ gap: 8 }}>
+          <div>
+            <dt className="muted">SCL</dt>
+            <dd><strong aria-live="polite">{profile.scl ?? 1}</strong></dd>
+          </div>
+          <div>
+            <dt className="muted">GitHub</dt>
+            <dd aria-live="polite">{profile.githubLinked ? 'Verknüpft' : 'Nicht verknüpft'}</dd>
+          </div>
+        </dl>
+
+        {canLink ? (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={linkGithub}
+            aria-label="GitHub verknüpfen"
+            data-testid="link-github"
+          >
+            GitHub verknüpfen
+          </button>
+        ) : (
+          <p className="muted" aria-live="polite">GitHub ist verknüpft. Danke!</p>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/app/src/routes/Quests.emptyState.cta.test.tsx
+++ b/apps/app/src/routes/Quests.emptyState.cta.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+describe('Quests empty-state CTA (link GitHub)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // default profile is unlocked false
+  });
+
+  it('shows CTA in GitHub filter and reveals GitHub quests after clicking', async () => {
+    render(<Quests />);
+    // switch to GitHub filter
+    fireEvent.click(screen.getByTestId('filter-github'));
+    // CTA should appear
+    const cta = screen.getByTestId('empty-link-github');
+    expect(cta).toBeInTheDocument();
+
+    // Click CTA to link
+    fireEvent.click(cta);
+
+  // After linking, wait for GitHub quest to appear
+  await screen.findByTestId('source-badge-github');
+  });
+});

--- a/apps/app/src/routes/Quests.emptyState.test.tsx
+++ b/apps/app/src/routes/Quests.emptyState.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+describe('Quests empty state', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows GitHub empty state when filter is GitHub but no GitHub quests available', () => {
+    // default profile has no github quests
+    render(<Quests />);
+    fireEvent.click(screen.getByTestId('filter-github'));
+    const empty = screen.getByTestId('empty-state');
+    expect(empty).toHaveTextContent(/Keine GitHub‑Quests verfügbar/i);
+  });
+});

--- a/apps/app/src/routes/Quests.filter.persist.test.tsx
+++ b/apps/app/src/routes/Quests.filter.persist.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+describe('Quests filter persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // unlock github quests for filtering to have both
+    localStorage.setItem('profile', JSON.stringify({ githubLinked: true, scl: 4 }));
+  });
+
+  it('loads initial filter from localStorage', () => {
+    localStorage.setItem('quests.filter', 'github');
+    render(<Quests />);
+    const githubRadio = screen.getByTestId('filter-github') as HTMLInputElement;
+    expect(githubRadio.checked).toBe(true);
+  });
+
+  it('persists filter selection to localStorage', () => {
+    render(<Quests />);
+    const localRadio = screen.getByTestId('filter-local');
+    fireEvent.click(localRadio);
+    expect(localStorage.getItem('quests.filter')).toBe('local');
+  });
+
+  it('inline CTA links GitHub from empty state and GitHub quests appear', async () => {
+    // ensure profile is NOT linked initially
+    localStorage.setItem('profile', JSON.stringify({ githubLinked: false, scl: 1 }));
+    render(<Quests />);
+    // Switch to GitHub filter (empty state visible)
+    fireEvent.click(screen.getByTestId('filter-github'));
+    const cta = await screen.findByTestId('empty-link-github');
+    fireEvent.click(cta);
+    // GitHub quest becomes visible
+    await screen.findByTestId('source-badge-github');
+    // Filter persisted as github (radio onChange persists)
+    expect(localStorage.getItem('quests.filter')).toBe('github');
+  });
+});

--- a/apps/app/src/routes/Quests.filter.test.tsx
+++ b/apps/app/src/routes/Quests.filter.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+function setProfile(v: any) {
+  localStorage.setItem('profile', JSON.stringify(v));
+}
+
+describe('Quests source filter', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('filters to GitHub-only when selected', () => {
+    setProfile({ githubLinked: true, scl: 4 });
+    render(<Quests />);
+
+    // Default: shows both local and github quests
+    expect(screen.getAllByTestId(/quest-item-/i).length).toBeGreaterThan(0);
+
+    const githubRadio = screen.getByTestId('filter-github');
+    fireEvent.click(githubRadio);
+
+    // After filtering: only github quests remain
+    const items = screen.getAllByTestId(/quest-item-/i);
+    for (const el of items) {
+      expect(el.getAttribute('data-testid')).toContain('github_issue');
+    }
+  });
+
+  it('filters to Local-only when selected', () => {
+    setProfile({ githubLinked: true, scl: 4 });
+    render(<Quests />);
+
+    const localRadio = screen.getByTestId('filter-local');
+    fireEvent.click(localRadio);
+
+    const items = screen.getAllByTestId(/quest-item-/i);
+    for (const el of items) {
+      expect(el.getAttribute('data-testid')).toContain('local');
+    }
+  });
+});

--- a/apps/app/src/routes/Quests.sourceBadge.test.tsx
+++ b/apps/app/src/routes/Quests.sourceBadge.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+describe('Quests source badge', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows Local badge for local quest', () => {
+    // default profile → only local dummy quest
+    render(<Quests />);
+    expect(screen.getByTestId('source-badge-local')).toBeInTheDocument();
+  });
+
+  it('shows GitHub badge when unlocked and mapped quest present', () => {
+    localStorage.setItem('profile', JSON.stringify({ githubLinked: true, scl: 4 }));
+    render(<Quests />);
+    expect(screen.getByTestId('source-badge-github')).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/routes/Quests.test.tsx
+++ b/apps/app/src/routes/Quests.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { Quests } from './Quests';
+
+function setProfile(v: any) {
+  localStorage.setItem('profile', JSON.stringify(v));
+}
+
+describe('Quests notice for GitHub unlock', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not show unlock notice by default', () => {
+    render(<Quests />);
+    expect(screen.queryByText(/GitHub‑Quests freigeschaltet/i)).toBeNull();
+  });
+
+  it('shows unlock notice when githubLinked and scl>=4', () => {
+    setProfile({ githubLinked: true, scl: 4 });
+    render(<Quests />);
+    expect(screen.getByText(/GitHub‑Quests freigeschaltet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/styles/global.css
+++ b/apps/app/src/styles/global.css
@@ -32,6 +32,14 @@ body {
   overflow-x: hidden;
 }
 
+/* Skip link for keyboard users */
+.skip-link {
+  position: absolute; left: 8px; top: -40px; z-index: 1000;
+  padding: 8px 12px; border-radius: 8px; background: #111827; color: #fff; text-decoration: none;
+  transition: top .2s ease;
+}
+.skip-link:focus { top: 8px; outline: 2px solid var(--accent); outline-offset: 2px; }
+
 /* Starfield layers */
 .bg-sky {
   position: fixed;

--- a/apps/app/tests/happy-path.spec.ts
+++ b/apps/app/tests/happy-path.spec.ts
@@ -11,4 +11,17 @@ test('happy path mobile 3-tap onboarding', async ({ page }) => {
   await page.getByRole('button', { name: 'Annehmen' }).click();
   await page.getByRole('button', { name: 'Erledigt' }).click();
   await expect(page.getByRole('status')).toHaveText(/Erledigt/);
+
+  // Extra: Link GitHub and verify a GitHub-sourced quest appears
+  await page.getByRole('link', { name: 'Ich' }).click();
+  await page.getByRole('button', { name: 'GitHub verknüpfen' }).click();
+  await page.getByRole('link', { name: 'Quests' }).click();
+  await expect(page.getByRole('status')).toHaveText(/GitHub‑Quests freigeschaltet/i);
+  await expect(page.getByRole('link', { name: /Breisgauleiter\/glocalsyn#1/ })).toBeVisible();
+
+  // Toggle filter to GitHub and ensure local quest disappears
+  await page.getByLabel('GitHub').click();
+  await expect(page.getByRole('article', { name: /Begrüße deinen Hub/ })).toHaveCount?.(0);
+  // Back to Alle
+  await page.getByLabel('Alle').click();
 });

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,9 +8,9 @@
 
 #### Deliverables
 - PWA-Shell mit Tab-Navigation (Home, Quests, Map, Hubs, Ich) – [DELIVERED: App-Shell]
-- Login-Flow + minimaler Profilwizard – [IN PROGRESS]
+- Login-Flow + minimaler Profilwizard – [DELIVERED]
 - Eine funktionsfähige Dummy-Quest (Client-seitig) – [DELIVERED]
-- Tests: E2E Happy Path – [DELIVERED]; Unit-Tests – [PENDING]
+- Tests: E2E Happy Path – [DELIVERED]; Unit-Tests – [DELIVERED]
 - Dokumentation: „How to run & test“ – [DELIVERED]
 - Klarstellung: Sacred Geometry nur als Design-System (keine Gameplay-Features)
 
@@ -24,6 +24,7 @@
 - Mindestens 3 Nachweisarten (Check-in, Foto, Peer-Bestätigung)
 - XP-System und Badge-Belohnungen
 - Review-Queue für Nachweise (Proof Verifier Rolle)
+ - Proof-Regeln (SCL 1–3): Abschluss der Quest genügt (Client‑Proof, datensparsam)
 
 ### Sprint 03 – Graph & Empfehlungen
 **Zeitrahmen**: 3 Wochen  
@@ -36,6 +37,9 @@
 - Graph-basierte Vielfaltsmechaniken
 - Start: GitHub‑Quests (SCL ≥ 4) – Account‑Link Flow (Opt‑in) + Quest‑Source‑Adapter (GitHub Issues, read‑only)
 - Aufstiegs‑Quest zu SCL 4 vorbereitet (Repo‑Verknüpfung als Quest)
+ - Aufstiegs‑Proof zu SCL 4: erfolgreiche Verknüpfung des Syntopia‑Accounts mit dem GitHub‑Account
+ - Proof‑Regeln (SCL ≥ 4): Nachweis = erfolgreich gereviewter PR, der das zugehörige Issue schließt (automatisch synchronisiert)
+ - Issue→Quest Pipeline: Issues aus den Repos „Syntopia“ (später auch „GLOCALSPIRIT“) füllen die Quests; Quelle (Repo/Issue) und Status werden angezeigt
 
 ## Phase 2: Community Features (Sprints 4-6)
 
@@ -78,6 +82,8 @@
 - Start ab Sprint 03: Quests aus echten GitHub‑Issues (Feature/Fix) – zunächst read‑only Adapter + Account‑Link Flow.
 - Aufstiegs‑Quest zu SCL 4: Verknüpfe dein Syntopia‑Profil mit einem GitHub‑Repository (Opt‑in, transparent, widerrufbar).
 - Erklärbarkeit: Anzeige der Quelle (Repo/Issue) und des Grundes für die Empfehlung.
+ - Pipeline: Syntopia‑ und GLOCALSPIRIT‑Issues → Syntopia‑Quests; das Erledigen via PR‑Merge/Issue‑Close lässt beide Repos und das Quest‑Angebot wachsen.
+ - Proof‑Zusammenfassung: SCL 1–3 = Questabschluss (Client‑Proof); ab SCL 4 = verknüpfter GitHub‑Account + gereviewter PR, der das Issue schließt.
 
 ## Meilensteine
 - **M1** (Ende Sprint 3): MVP lauffähig, erste 100 Beta-Tester

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './governance';
+export * from './quests';

--- a/shared/types/src/quests.ts
+++ b/shared/types/src/quests.ts
@@ -1,0 +1,45 @@
+import type { SCLLevel } from './governance';
+
+export type ProofType = 'complete' | 'github_pr';
+
+export interface ProofPolicy {
+  type: ProofType;
+  requiredSCL?: SCLLevel;
+  description: string;
+}
+
+export interface GitHubIssueLite {
+  id: number;
+  number: number;
+  title: string;
+  body?: string;
+  url: string; // html_url
+  repo: string; // owner/repo
+  labels?: string[];
+}
+
+export interface QuestDTO {
+  id: string;
+  title: string;
+  description: string;
+  category: 'daily' | 'weekly' | 'story';
+  minimumSCL?: SCLLevel;
+  proof: ProofPolicy;
+  source?: { kind: 'github_issue'; repo: string; number: number; url: string };
+}
+
+export function mapIssueToQuest(issue: GitHubIssueLite): QuestDTO {
+  return {
+    id: `gh-${issue.repo}#${issue.number}`,
+    title: issue.title,
+    description: issue.body ?? `Issue #${issue.number} aus ${issue.repo}`,
+    category: 'story',
+    minimumSCL: 4 as SCLLevel,
+    proof: {
+      type: 'github_pr',
+      requiredSCL: 4 as SCLLevel,
+      description: 'Nachweis: PR wurde erfolgreich gereviewt und schließt das Issue.'
+    },
+    source: { kind: 'github_issue', repo: issue.repo, number: issue.number, url: issue.url },
+  };
+}


### PR DESCRIPTION
Summary
- Link GitHub stub on Me: sets githubLinked=true and ensures SCL≥4; a11y labels; persisted via profile store.
- Quest feed now merges SCL≥4 + linked GitHub Issues (mock) with existing local quest using shared types mapping.
- Unlock notice shown when GitHub quests become available; auto-switch to GitHub filter on unlock with brief highlight.
- Source filter (All | GitHub | Lokal) with persistence; source badges per quest.
- Empty states for filters; inline CTA in GitHub filter to link GitHub (updates profile + auto-switch).
- Tests: unit tests for profile store, quest gating/mapping, filters, persistence, badges, empty states, unlock notice; E2E extended to link GitHub and verify GitHub quest link; build remains green.
- Docs: ROADMAP updated with proof rules and Issue→Quest pipeline; README quick start updated.

How to test
1) Unit tests
- pnpm -w -F @syntopia/app test (Vitest): should pass all tests, including new files under routes and features.

2) E2E
- pnpm -w -F @syntopia/app e2e (ensure `pnpm -w -F @syntopia/app e2e:install` ran once):
  - Happy path now also links GitHub on Me and verifies unlock notice and GitHub quest link on Quests.

3) Manual smoke
- Dev: pnpm -w -F @syntopia/app dev
- Profile → "GitHub verknüpfen"; navigate to Quests: unlock notice appears, GitHub filter auto-selected, GitHub quest highlighted briefly, source badges shown.
- Toggle filter radio buttons and reload; selection persists.

Screenshots
- Unlock notice + mixed list (All):

  ![quests-unlocked](https://raw.githubusercontent.com/Breisgauleiter/glocalsyn/feat/github-link-feed-ui/apps/app/docs/media/quests-unlocked.png)

- Filter set to GitHub (GitHub-only list):

  ![quests-filter-github](https://raw.githubusercontent.com/Breisgauleiter/glocalsyn/feat/github-link-feed-ui/apps/app/docs/media/quests-filter-github.png)

Notes
- Shared types introduce QuestDTO/ProofPolicy and mapIssueToQuest; mock issues kept client-side and read-only for now.
- A11y: page landmarks, labels, polite status updates, explicit button types.
- Licenses: no GPL/AGPL deps added.

Follow-ups (separate PRs)
- Live GitHub adapter (read-only) + pagination, repo selection.
- Enforce PR→Issue close semantics and status sync, incl. badges for PR state.
- I18n EN/DE strings for new UI.