### PR TITLE
feat(app): read-only GitHub adapter (flagged off) + unit test

### DIFF
--- a/apps/app/.turbo/turbo-build.log
+++ b/apps/app/.turbo/turbo-build.log
@@ -4,9 +4,9 @@
 > vite build
 
 [36mvite v5.4.19 [32mbuilding for production...[36m[39m
-[2K[1Gtransforming (1) [2mindex.html[22m[2K[1Gtransforming (5) [2m../../node_modules/.pnpm/react-router-dom@6.30.1_react-dom@18.3.1_re[2K[1Gtransforming (13) [2m../../node_modules/.pnpm/react@18.3.1/node_modules/react/cjs/react.[2K[1Gtransforming (30) [2msrc/components/Background.tsx[22m[2K[1Gtransforming (34) [2m../../node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules[2K[1G[32m✓[39m 44 modules transformed.
+[2K[1Gtransforming (1) [2mindex.html[22m[2K[1Gtransforming (13) [2msrc/App.tsx[22m[2K[1Gtransforming (31) [2msrc/components/Background.tsx[22m[2K[1Gtransforming (40) [2m../../node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules[2K[1G[32m✓[39m 49 modules transformed.
 [2K[1Grendering chunks (1)...[2K[1G[2K[1Gcomputing gzip size (0)...[2K[1Gcomputing gzip size (1)...[2K[1Gcomputing gzip size (2)...[2K[1Gcomputing gzip size (3)...[2K[1G[2mdist/[22m[32mindex.html                 [39m[1m[2m  0.44 kB[22m[1m[22m[2m │ gzip:  0.28 kB[22m
 [2mdist/[22m[2massets/[22m[32mtree-CE_yy9O8.png   [39m[1m[2m625.12 kB[22m[1m[22m
-[2mdist/[22m[2massets/[22m[35mindex-CVTBcjpH.css  [39m[1m[2m  5.91 kB[22m[1m[22m[2m │ gzip:  1.89 kB[22m
-[2mdist/[22m[2massets/[22m[36mindex-CbWVa61r.js   [39m[1m[2m212.96 kB[22m[1m[22m[2m │ gzip: 69.19 kB[22m
-[32m✓ built in 1.73s[39m
+[2mdist/[22m[2massets/[22m[35mindex-CEfVFGTo.css  [39m[1m[2m  6.16 kB[22m[1m[22m[2m │ gzip:  1.96 kB[22m
+[2mdist/[22m[2massets/[22m[36mindex-D1uKASdA.js   [39m[1m[2m218.33 kB[22m[1m[22m[2m │ gzip: 70.83 kB[22m
+[32m✓ built in 1.07s[39m

--- a/apps/app/src/features/quests/githubAdapter.test.ts
+++ b/apps/app/src/features/quests/githubAdapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RealGithubAdapter } from './githubAdapter';
+
+const sampleIssues = [
+  {
+    id: 1,
+    number: 101,
+    title: 'Fix login bug',
+    body: 'Details...',
+    html_url: 'https://github.com/foo/bar/issues/101',
+    labels: [{ name: 'bug' }, { name: 'good first issue' }],
+  },
+  {
+    id: 2,
+    number: 102,
+    title: 'Docs update',
+    body: null,
+    html_url: 'https://github.com/foo/bar/issues/102',
+    labels: [],
+  },
+  {
+    id: 3,
+    number: 7,
+    title: 'This is a PR not an issue',
+    html_url: 'https://github.com/foo/bar/pull/7',
+    pull_request: { url: 'https://api.github.com/repos/foo/bar/pulls/7' },
+  },
+];
+
+describe('RealGithubAdapter (read-only)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn(async (url: any) => {
+      if (String(url).includes('/repos/foo/bar/issues')) {
+        return {
+          ok: true,
+          json: async () => sampleIssues,
+        } as any;
+      }
+      return { ok: false, json: async () => ({}) } as any;
+    }) as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch as any;
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('maps GitHub issues to GitHubIssueLite and filters PRs', async () => {
+    const adapter = new RealGithubAdapter({ perRepoLimit: 5 });
+    const items = await adapter.listIssues(['foo/bar']);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: 1,
+      number: 101,
+      title: 'Fix login bug',
+      body: 'Details...',
+      url: 'https://github.com/foo/bar/issues/101',
+      repo: 'foo/bar',
+      labels: ['bug', 'good first issue'],
+    });
+    expect(items[1]).toMatchObject({
+      id: 2,
+      number: 102,
+      title: 'Docs update',
+      body: undefined,
+      url: 'https://github.com/foo/bar/issues/102',
+      repo: 'foo/bar',
+    });
+  });
+});

--- a/apps/app/src/features/quests/githubAdapter.ts
+++ b/apps/app/src/features/quests/githubAdapter.ts
@@ -1,0 +1,75 @@
+import type { GitHubIssueLite } from '../../../../../shared/types/src';
+
+export interface GithubAdapterOptions {
+  token?: string; // optional, for higher rate limits
+  perRepoLimit?: number; // cap number of issues per repo
+  state?: 'open' | 'closed' | 'all';
+  labels?: string[];
+}
+
+export interface GithubAdapter {
+  listIssues(repos: string[]): Promise<GitHubIssueLite[]>;
+}
+
+export class RealGithubAdapter implements GithubAdapter {
+  private token?: string;
+  private perRepoLimit: number;
+  private state: 'open' | 'closed' | 'all';
+  private labels?: string[];
+
+  constructor(opts: GithubAdapterOptions = {}) {
+    this.token = opts.token;
+    this.perRepoLimit = opts.perRepoLimit ?? 10;
+    this.state = opts.state ?? 'open';
+    this.labels = opts.labels;
+  }
+
+  async listIssues(repos: string[]): Promise<GitHubIssueLite[]> {
+    const headers: Record<string, string> = { 'Accept': 'application/vnd.github+json' };
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+
+    const qs = new URLSearchParams({ state: this.state, per_page: String(this.perRepoLimit) });
+    if (this.labels?.length) qs.set('labels', this.labels.join(','));
+
+    const out: GitHubIssueLite[] = [];
+    for (const repo of repos) {
+      // Basic validation for owner/repo
+      if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) continue;
+      const url = `https://api.github.com/repos/${repo}/issues?${qs.toString()}`;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        // Skip this repo on API error; keep adapter tolerant for now (read-only, best-effort)
+        continue;
+      }
+      const data: any[] = await res.json();
+      for (const it of data) {
+        // Filter out PRs (GitHub returns PRs in the issues list when using the issues endpoint)
+        if (it.pull_request) continue;
+        out.push({
+          id: it.id,
+          number: it.number,
+          title: it.title,
+          body: it.body ?? undefined,
+          url: it.html_url,
+          repo,
+          labels: Array.isArray(it.labels) ? it.labels.map((l: any) => (typeof l === 'string' ? l : l?.name)).filter(Boolean) : undefined,
+        });
+      }
+    }
+    return out;
+  }
+}
+
+// Helper to read a feature flag safely (string "true" -> true)
+export function isGithubAdapterEnabled(): boolean {
+  // Vite: import.meta.env; fall back to process.env for tests
+  const raw = (import.meta as any)?.env?.VITE_USE_GITHUB_ADAPTER ?? (typeof process !== 'undefined' ? (process.env?.VITE_USE_GITHUB_ADAPTER as any) : undefined);
+  return String(raw).toLowerCase() === 'true';
+}
+
+export function createGithubAdapterFromEnv(): GithubAdapter {
+  const token = (import.meta as any)?.env?.VITE_GITHUB_TOKEN ?? (typeof process !== 'undefined' ? process.env?.VITE_GITHUB_TOKEN : undefined);
+  const perRepoLimitStr = (import.meta as any)?.env?.VITE_GITHUB_PER_REPO_LIMIT ?? (typeof process !== 'undefined' ? process.env?.VITE_GITHUB_PER_REPO_LIMIT : undefined);
+  const perRepoLimit = perRepoLimitStr ? parseInt(String(perRepoLimitStr), 10) : undefined;
+  return new RealGithubAdapter({ token, perRepoLimit });
+}

--- a/shared/types/.turbo/turbo-build.log
+++ b/shared/types/.turbo/turbo-build.log
@@ -1,5 +1,4 @@
 
-
 > @syntopia/types@0.1.0 build /Users/orlandoberger/develop/SYNREACT/shared/types
 > tsc -p tsconfig.json
 


### PR DESCRIPTION
Summary
- Add a small read-only GitHub adapter to list issues from configured repos.
- Feature-flagged via VITE_USE_GITHUB_ADAPTER (default off). Not wired into UI/store yet.
- Includes unit test with mocked fetch; filters PRs from the issues endpoint; maps to GitHubIssueLite.

Why
- Prepares Sprint 03 item: Quest-Source-Adapter (GitHub Issues, read-only), keeping current UX stable.

Details
- Adapter supports optional token + perRepoLimit, returns GitHubIssueLite[] for owner/repo slugs.
- Best-effort error handling: skips repos on HTTP errors.
- No E2E dependency; unit-only to keep CI fast/flaky-free.

Testing
- Unit tests added (Vitest). All tests pass locally.

Flagging
- Use VITE_USE_GITHUB_ADAPTER=true and VITE_GITHUB_TOKEN=... locally to test the adapter manually in later wiring.
