### PR TITLE
feat(app): wire read-only GitHub adapter behind env flag + tests + docs

### DIFF
--- a/apps/app/src/features/quests/questStore.github.flag.test.tsx
+++ b/apps/app/src/features/quests/questStore.github.flag.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useQuestStore, getQuestsForProfile } from './questStore';
+
+// Helper to set and restore env between tests
+const originalEnv = { ...process.env };
+
+describe('useQuestStore with GitHub adapter flag', () => {
+  beforeEach(() => {
+    process.env.VITE_USE_GITHUB_ADAPTER = 'true';
+    process.env.VITE_GITHUB_REPOS = 'foo/bar';
+  });
+
+  afterEach(() => {
+    // Restore env
+    Object.keys(process.env).forEach((k) => { delete (process.env as any)[k]; });
+    Object.assign(process.env, originalEnv);
+    vi.clearAllMocks();
+  });
+
+  it('keeps baseline immediately and enriches with adapter results when enabled', async () => {
+    // Mock fetch to return 1 issue
+    const sampleIssue = [{ id: 10, number: 77, title: 'Adapter test', html_url: 'https://github.com/foo/bar/issues/77' }];
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({ ok: true, json: async () => sampleIssue })) as any;
+
+    try {
+      const { result } = renderHook(() => useQuestStore({ scl: 4, githubLinked: true } as any));
+      // Baseline should include dummy quest
+      expect(result.current.quests.find((q) => q.id === 'q1')).toBeTruthy();
+
+      // Wait for enrichment
+  await waitFor(() => {
+        const gh = result.current.quests.find((q) => q.source?.kind === 'github_issue');
+        expect(gh).toBeTruthy();
+      });
+    } finally {
+      global.fetch = originalFetch as any;
+    }
+  });
+
+  it('does not call adapter when flag is off', async () => {
+    process.env.VITE_USE_GITHUB_ADAPTER = 'false';
+    const spy = vi.spyOn(global, 'fetch' as any);
+    const { result } = renderHook(() => useQuestStore({ scl: 4, githubLinked: true } as any));
+    // Baseline only; no fetch calls
+    expect(result.current.quests.find((q) => q.id === 'q1')).toBeTruthy();
+  // Give microtasks a tick
+  await Promise.resolve();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,3 +43,16 @@ pnpm --filter @syntopia/app test
 - `e2e` – run Playwright tests
 - `e2e:install` – install Playwright browsers
 - `test` – run Vitest (jsdom)
+
+## Optional: GitHub adapter (read-only) flags
+
+To enable read-only GitHub issues as a quest source (for users with SCL ≥ 4 and linked GitHub):
+
+- VITE_USE_GITHUB_ADAPTER=true
+- VITE_GITHUB_REPOS="owner1/repo1,owner2/repo2"  # comma-separated
+- (optional) VITE_GITHUB_TOKEN=ghp_xxx            # increases rate limit
+- (optional) VITE_GITHUB_PER_REPO_LIMIT=10        # default 10
+
+Notes:
+- Adapter is read-only and best-effort. On errors it falls back to the baseline mock.
+- The dummy onboarding quest remains; when enabled, GitHub quests are added on top.


### PR DESCRIPTION
Summary
- Wire the new read-only GitHub adapter into the quest store behind VITE_USE_GITHUB_ADAPTER.
- Keep baseline (dummy + mock issues) first; when enabled and SCL≥4 + linked, enrich with live GitHub issues from configured repos.
- Add unit tests for flag on/off behavior. Update GETTING_STARTED with env flags.

Why
- Implements Sprint 03 step: Quest-Source-Adapter (GitHub Issues, read-only) in a safe, opt-in way.

Details
- Env flags: VITE_USE_GITHUB_ADAPTER, VITE_GITHUB_REPOS (comma-separated), optional VITE_GITHUB_TOKEN, VITE_GITHUB_PER_REPO_LIMIT.
- Best-effort: on errors, keep baseline; no UI regression.

Testing
- Vitest suite extended; all tests pass locally. No E2E changes.
