### PR TITLE
feat(profile): per-user GitHub repo selection; quests prefer profile repos; tests/docs

### DIFF
--- a/apps/app/src/features/profile/profileStore.ts
+++ b/apps/app/src/features/profile/profileStore.ts
@@ -6,6 +6,7 @@ export interface Profile {
   region?: string;
   scl: SCLLevel;
   githubLinked: boolean;
+  githubRepos?: string[]; // optional per-user repo selection (overrides env if set)
 }
 
 const DEFAULT_PROFILE: Profile = { scl: 1 as SCLLevel, githubLinked: false };
@@ -18,7 +19,19 @@ export function useProfile() {
     if (raw) {
       try {
         const parsed = JSON.parse(raw) as Partial<Profile>;
-        setProfile({ ...DEFAULT_PROFILE, ...parsed });
+        // Normalize githubRepos if someone stored a string earlier
+        const normalized: Partial<Profile> = {
+          ...parsed,
+          githubRepos: Array.isArray((parsed as any).githubRepos)
+            ? (parsed as any).githubRepos
+            : typeof (parsed as any).githubRepos === 'string'
+              ? String((parsed as any).githubRepos)
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter(Boolean)
+              : parsed.githubRepos,
+        };
+        setProfile({ ...DEFAULT_PROFILE, ...normalized });
       } catch {}
     }
   }, []);

--- a/apps/app/src/features/quests/questStore.ts
+++ b/apps/app/src/features/quests/questStore.ts
@@ -62,9 +62,11 @@ export function useQuestStore(profileOverride?: Profile) {
     const canUseAdapter = profile.githubLinked && profile.scl >= 4 && isGithubAdapterEnabled();
     if (!canUseAdapter) return;
 
-    const envAny = (import.meta as any)?.env ?? (typeof process !== 'undefined' ? (process.env as any) : {});
-    const reposRaw = envAny.VITE_GITHUB_REPOS as string | undefined;
-    const repos = (reposRaw ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const profileRepos = Array.isArray((profile as any).githubRepos) ? (profile as any).githubRepos as string[] : undefined;
+  const envAny = (import.meta as any)?.env ?? (typeof process !== 'undefined' ? (process.env as any) : {});
+  const reposRaw = envAny.VITE_GITHUB_REPOS as string | undefined;
+  const reposFromEnv = (reposRaw ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const repos = (profileRepos && profileRepos.length > 0) ? profileRepos : reposFromEnv;
     if (repos.length === 0) return; // no configured repos -> keep baseline
 
     const adapter = createGithubAdapterFromEnv();

--- a/apps/app/src/routes/Me.tsx
+++ b/apps/app/src/routes/Me.tsx
@@ -1,13 +1,23 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useProfile } from '../features/profile/profileStore';
 
 export function Me() {
   const { profile, update } = useProfile();
   const canLink = useMemo(() => !profile.githubLinked, [profile.githubLinked]);
+  const [reposInput, setReposInput] = useState<string>(() => (profile.githubRepos ?? []).join(', '));
 
   function linkGithub() {
     const nextScl = Math.max(profile.scl ?? 1, 4);
     update({ githubLinked: true, scl: nextScl as any });
+  }
+
+  function saveRepos(e: React.FormEvent) {
+    e.preventDefault();
+    const repos = reposInput
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    update({ githubRepos: repos });
   }
 
   return (
@@ -39,7 +49,25 @@ export function Me() {
             GitHub verknüpfen
           </button>
         ) : (
-          <p className="muted" aria-live="polite">GitHub ist verknüpft. Danke!</p>
+          <>
+            <p className="muted" aria-live="polite">GitHub ist verknüpft. Danke!</p>
+            <form onSubmit={saveRepos} className="stack" style={{ gap: 8 }} aria-label="GitHub Repos auswählen">
+              <label htmlFor="repos-input" className="muted">Repos (owner/name, komma-separiert)</label>
+              <input
+                id="repos-input"
+                name="repos"
+                type="text"
+                value={reposInput}
+                onChange={(e) => setReposInput(e.target.value)}
+                placeholder="owner1/repo1, owner2/repo2"
+                aria-describedby="repos-help"
+              />
+              <small id="repos-help" className="muted">Diese Auswahl überschreibt die Standard-Repo-Liste. Leer lassen = Standard verwenden.</small>
+              <div>
+                <button type="submit" className="btn">Speichern</button>
+              </div>
+            </form>
+          </>
         )}
       </div>
     </section>

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -56,3 +56,4 @@ To enable read-only GitHub issues as a quest source (for users with SCL ≥ 4 an
 Notes:
 - Adapter is read-only and best-effort. On errors it falls back to the baseline mock.
 - The dummy onboarding quest remains; when enabled, GitHub quests are added on top.
+- Per-user Repo-Auswahl: Nach dem Verknüpfen kann jede:r in "Ich" eine Repo-Liste (owner/name, komma-separiert) speichern. Diese überschreibt `VITE_GITHUB_REPOS`. Leer lassen = Standard verwenden.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,6 +41,19 @@
  - Proof‑Regeln (SCL ≥ 4): Nachweis = erfolgreich gereviewter PR, der das zugehörige Issue schließt (automatisch synchronisiert)
  - Issue→Quest Pipeline: Issues aus den Repos „Syntopia“ (später auch „GLOCALSPIRIT“) füllen die Quests; Quelle (Repo/Issue) und Status werden angezeigt
 
+#### Fortschritt (11.08.2025)
+- Account‑Link Flow (Opt‑in) [DELIVERED]
+- Read‑only GitHub Issues Adapter [DELIVERED] und hinter Feature‑Flag verdrahtet (default: off)
+- UI für Quests: Source‑Badges, Filter (persistiert), leere Zustände mit CTA [DELIVERED]
+- Tests: Unit + E2E grün; CI‑Workflow grün [DELIVERED]
+- Doku: GETTING_STARTED mit Env‑Flags (VITE_USE_GITHUB_ADAPTER, VITE_GITHUB_REPOS, optional TOKEN, LIMIT) [DELIVERED]
+
+Nächste Schritte (kleine PRs):
+- Repo‑Auswahl‑UI (mehrere Repos, Opt‑in je Repo)
+- Pagination/Limit für Adapter, defensive Rate‑Limit‑Handhabung
+- Semantik: PR→Issue‑Close‑Erzwingung für Proofs ab SCL ≥ 4 (read‑only bleibt vorerst bestehen)
+- I18n: DE/EN Texte für neue UI‑Elemente
+
 ## Phase 2: Community Features (Sprints 4-6)
 
 ### Sprint 04 – Hubs & Lokale Partner
@@ -84,6 +97,8 @@
 - Erklärbarkeit: Anzeige der Quelle (Repo/Issue) und des Grundes für die Empfehlung.
  - Pipeline: Syntopia‑ und GLOCALSPIRIT‑Issues → Syntopia‑Quests; das Erledigen via PR‑Merge/Issue‑Close lässt beide Repos und das Quest‑Angebot wachsen.
  - Proof‑Zusammenfassung: SCL 1–3 = Questabschluss (Client‑Proof); ab SCL 4 = verknüpfter GitHub‑Account + gereviewter PR, der das Issue schließt.
+
+Status (11.08.2025): Read‑only Adapter in App verdrahtet (Feature‑Flag: VITE_USE_GITHUB_ADAPTER), Repos via VITE_GITHUB_REPOS; Standard: off. Unit+E2E abgedeckt, CI grün. Nächster Meilenstein: selektive Repo‑Verknüpfung und verbesserte Proof‑Semantik.
 
 ## Meilensteine
 - **M1** (Ende Sprint 3): MVP lauffähig, erste 100 Beta-Tester


### PR DESCRIPTION
This PR introduces per-user GitHub repo selection and wires it into the quest feed.

What changed
- Profile: add optional `githubRepos: string[]` persisted to localStorage (with normalization for legacy string values).
- Me route: simple, accessible input to edit comma-separated `owner/name` repos when GitHub is linked.
- Quest store: when GitHub adapter is enabled and SCL ≥ 4 + linked, prefer `profile.githubRepos` over `VITE_GITHUB_REPOS`.
- Adapter: parallelize `listIssues` across repos for better latency.
- Tests: extend flag test to verify profile repos override env; all tests passing (21/21 locally).
- Docs: GETTING_STARTED documents per-user repo selection overriding env.

Guardrails
- Feature flag remains: VITE_USE_GITHUB_ADAPTER controls network calls.
- Best-effort behavior; errors keep baseline quests intact.
- Dummy onboarding quest remains first.

DoD
- Unit tests green.
- CI should pass (no E2E behavior change).

Follow-ups (next small PRs)
- Basic validation and feedback in Me route for invalid repo format.
- Optional label/state filters UI.
- Persisted token UI (for higher rate limits) using secure storage when applicable.